### PR TITLE
Allow for either number or object prop types being passed for image.

### DIFF
--- a/lib/ImageWrapperComponent.js
+++ b/lib/ImageWrapperComponent.js
@@ -87,7 +87,10 @@ export default class ImageWrapperComponent extends Component {
 }
 
 ImageWrapperComponent.propTypes = {
-  image: PropTypes.object,
+  image: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
   imageResizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch', 'repeat']),
   gradientColors: PropTypes.array,
   gradientStart: PropTypes.object,

--- a/lib/StretchyFlatList.js
+++ b/lib/StretchyFlatList.js
@@ -69,7 +69,10 @@ export default class StretchyFlatList extends StretchyBase {
 
 StretchyFlatList.propTypes = {
   backgroundColor: PropTypes.string,
-  image: PropTypes.object,
+  image: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
   imageHeight: PropTypes.number,
   imageResizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch', 'repeat']),
   gradientColors: PropTypes.array,

--- a/lib/StretchySectionList.js
+++ b/lib/StretchySectionList.js
@@ -63,7 +63,10 @@ export default class StretchySectionList extends StretchyBase {
 
 StretchySectionList.propTypes = {
   backgroundColor: PropTypes.string,
-  image: PropTypes.object,
+  image: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
   imageHeight: PropTypes.number,
   imageResizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch', 'repeat']),
   gradientColors: PropTypes.array,


### PR DESCRIPTION
Require returns a number instead of an object. Therefore proptypes should allow either a number or object(in the event it is a network image for { uri: 'the image url' }) to be passed.